### PR TITLE
Upgrade projects

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -1,8 +1,0 @@
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="OutDir;Configuration">
-  <PropertyGroup>
-    <RepositoryRootDirectory>$(MSBuildThisFileDirectory)</RepositoryRootDirectory>
-  </PropertyGroup>
-
-  <Import Project="build\Settings.props" />
-
-</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,15 +1,13 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="OutDir;Configuration">
 
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 
+    <RepositoryRootDirectory>$(MSBuildThisFileDirectory)</RepositoryRootDirectory>
     <OutputPath>$([System.IO.Path]::GetFullPath('$(RepositoryRootDirectory)bin\$(Configuration)\$(MSBuildProjectName)'))\</OutputPath>
     <BaseIntermediateOutputPath>$([System.IO.Path]::GetFullPath('$(RepositoryRootDirectory)bin\obj\$(MSBuildProjectName)'))\</BaseIntermediateOutputPath>
   </PropertyGroup>
-
-  <Import Project="Packages.props" />
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,18 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="AvalonDock-1.x" Version="1.3.3600.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageVersion Include="Moq" Version="4.7.142" />
+    <PackageVersion Include="NUnit" Version="3.8.1" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageVersion Include="System.Composition" Version="1.1.0" />
+    <PackageVersion Include="System.Reflection.Emit.ILGeneration" Version="4.3.0" />
+    <PackageVersion Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,13 +6,13 @@
 
   <ItemGroup>
     <PackageVersion Include="AvalonDock-1.x" Version="1.3.3600.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageVersion Include="Moq" Version="4.7.142" />
-    <PackageVersion Include="NUnit" Version="3.8.1" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="3.8.0" />
-    <PackageVersion Include="System.Composition" Version="1.1.0" />
-    <PackageVersion Include="System.Reflection.Emit.ILGeneration" Version="4.3.0" />
-    <PackageVersion Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="NUnit" Version="4.4.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="5.1.0" />
+    <PackageVersion Include="System.Composition" Version="9.0.9" />
+    <PackageVersion Include="System.Reflection.Emit.ILGeneration" Version="4.7.0" />
+    <PackageVersion Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>
 
 </Project>

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <PropertyGroup>
-  </PropertyGroup>
-
-</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
-
-</Project>

--- a/src/ZDebug.Compiler/ZDebug.Compiler.csproj
+++ b/src/ZDebug.Compiler/ZDebug.Compiler.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit.ILGeneration" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ZDebug.IO/Utilities/DpiHelper.cs
+++ b/src/ZDebug.IO/Utilities/DpiHelper.cs
@@ -1,17 +1,9 @@
-﻿using System.Windows;
-using System.Windows.Media;
+﻿using System.Windows.Media;
 
 namespace ZDebug.IO.Utilities
 {
     public static class DpiHelper
     {
-        public static float GetPixelsPerDip()
-        {
-            return Application.Current.MainWindow is Window mainWindow
-                ? (float)VisualTreeHelper.GetDpi(mainWindow).PixelsPerDip
-                : 1.0f;
-        }
-
         public static float GetPixelsPerDip(this Visual visual)
         {
             return visual != null

--- a/src/ZDebug.IO/Utilities/DpiHelper.cs
+++ b/src/ZDebug.IO/Utilities/DpiHelper.cs
@@ -1,0 +1,22 @@
+﻿using System.Windows;
+using System.Windows.Media;
+
+namespace ZDebug.IO.Utilities
+{
+    public static class DpiHelper
+    {
+        public static float GetPixelsPerDip()
+        {
+            return Application.Current.MainWindow is Window mainWindow
+                ? (float)VisualTreeHelper.GetDpi(mainWindow).PixelsPerDip
+                : 1.0f;
+        }
+
+        public static float GetPixelsPerDip(this Visual visual)
+        {
+            return visual != null
+                ? (float)VisualTreeHelper.GetDpi(visual).PixelsPerDip
+                : 1.0f;
+        }   
+    }
+}

--- a/src/ZDebug.IO/Windows/ZTextBufferWindow.cs
+++ b/src/ZDebug.IO/Windows/ZTextBufferWindow.cs
@@ -5,9 +5,8 @@ using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
-using ZDebug.IO.Services;
 using System.Windows.Threading;
-using System.Windows.Controls.Primitives;
+using ZDebug.IO.Services;
 using ZDebug.IO.Utilities;
 
 namespace ZDebug.IO.Windows
@@ -52,7 +51,7 @@ namespace ZDebug.IO.Windows
                 typeface: new Typeface(FontsAndColorsService.NormalFontFamily, FontStyles.Normal, FontWeights.Normal, FontStretches.Normal),
                 emSize: FontsAndColorsService.FontSize,
                 foreground: FontsAndColorsService.DefaultForeground,
-                pixelsPerDip: DpiHelper.GetPixelsPerDip());
+                pixelsPerDip: this.GetPixelsPerDip());
 
             fontCharSize = new Size(zero.Width, zero.Height);
         }

--- a/src/ZDebug.IO/Windows/ZTextBufferWindow.cs
+++ b/src/ZDebug.IO/Windows/ZTextBufferWindow.cs
@@ -8,6 +8,7 @@ using System.Windows.Media;
 using ZDebug.IO.Services;
 using System.Windows.Threading;
 using System.Windows.Controls.Primitives;
+using ZDebug.IO.Utilities;
 
 namespace ZDebug.IO.Windows
 {
@@ -50,7 +51,8 @@ namespace ZDebug.IO.Windows
                 flowDirection: FlowDirection.LeftToRight,
                 typeface: new Typeface(FontsAndColorsService.NormalFontFamily, FontStyles.Normal, FontWeights.Normal, FontStretches.Normal),
                 emSize: FontsAndColorsService.FontSize,
-                foreground: FontsAndColorsService.DefaultForeground);
+                foreground: FontsAndColorsService.DefaultForeground,
+                pixelsPerDip: DpiHelper.GetPixelsPerDip());
 
             fontCharSize = new Size(zero.Width, zero.Height);
         }

--- a/src/ZDebug.IO/Windows/ZTextGrid.cs
+++ b/src/ZDebug.IO/Windows/ZTextGrid.cs
@@ -82,7 +82,7 @@ namespace ZDebug.IO.Windows
                 typeface: GetTypeface(),
                 emSize: FontsAndColorsService.FontSize,
                 foreground: FontsAndColorsService.DefaultForeground,
-                pixelsPerDip: DpiHelper.GetPixelsPerDip());
+                pixelsPerDip: this.GetPixelsPerDip());
 
             fontCharSize = new Size(zero.Width, zero.Height);
 
@@ -172,7 +172,7 @@ namespace ZDebug.IO.Windows
                         fg,
                         new NumberSubstitution(NumberCultureSource.User, CultureInfo.CurrentUICulture, NumberSubstitutionMethod.AsCulture),
                         TextFormattingMode.Display,
-                        pixelsPerDip: DpiHelper.GetPixelsPerDip()),
+                        pixelsPerDip: this.GetPixelsPerDip()),
                     new Point(x, y));
 
                 textContext.Close();

--- a/src/ZDebug.IO/Windows/ZTextGrid.cs
+++ b/src/ZDebug.IO/Windows/ZTextGrid.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Media;
 using ZDebug.IO.Services;
+using ZDebug.IO.Utilities;
 
 namespace ZDebug.IO.Windows
 {
@@ -80,7 +81,8 @@ namespace ZDebug.IO.Windows
                 flowDirection: FlowDirection.LeftToRight,
                 typeface: GetTypeface(),
                 emSize: FontsAndColorsService.FontSize,
-                foreground: FontsAndColorsService.DefaultForeground);
+                foreground: FontsAndColorsService.DefaultForeground,
+                pixelsPerDip: DpiHelper.GetPixelsPerDip());
 
             fontCharSize = new Size(zero.Width, zero.Height);
 
@@ -169,7 +171,8 @@ namespace ZDebug.IO.Windows
                         FontsAndColorsService.FontSize,
                         fg,
                         new NumberSubstitution(NumberCultureSource.User, CultureInfo.CurrentUICulture, NumberSubstitutionMethod.AsCulture),
-                        TextFormattingMode.Display),
+                        TextFormattingMode.Display,
+                        pixelsPerDip: DpiHelper.GetPixelsPerDip()),
                     new Point(x, y));
 
                 textContext.Close();

--- a/src/ZDebug.IO/Windows/ZTextGridWindow.cs
+++ b/src/ZDebug.IO/Windows/ZTextGridWindow.cs
@@ -26,7 +26,7 @@ namespace ZDebug.IO.Windows
                 typeface: FontsAndColorsService.FixedTypeface,
                 emSize: FontsAndColorsService.FontSize,
                 foreground: Brushes.Black,
-                pixelsPerDip: DpiHelper.GetPixelsPerDip());
+                pixelsPerDip: this.GetPixelsPerDip());
 
             fontCharSize = new Size(zero.Width, zero.Height);
 

--- a/src/ZDebug.IO/Windows/ZTextGridWindow.cs
+++ b/src/ZDebug.IO/Windows/ZTextGridWindow.cs
@@ -3,6 +3,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using ZDebug.IO.Services;
+using ZDebug.IO.Utilities;
 
 namespace ZDebug.IO.Windows
 {
@@ -24,7 +25,8 @@ namespace ZDebug.IO.Windows
                 flowDirection: FlowDirection.LeftToRight,
                 typeface: FontsAndColorsService.FixedTypeface,
                 emSize: FontsAndColorsService.FontSize,
-                foreground: Brushes.Black);
+                foreground: Brushes.Black,
+                pixelsPerDip: DpiHelper.GetPixelsPerDip());
 
             fontCharSize = new Size(zero.Width, zero.Height);
 

--- a/src/ZDebug.IO/ZDebug.IO.csproj
+++ b/src/ZDebug.IO/ZDebug.IO.csproj
@@ -1,14 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
+    <UseWpf>true</UseWpf>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
 
 </Project>

--- a/src/ZDebug.PerfHarness/ZDebug.PerfHarness.csproj
+++ b/src/ZDebug.PerfHarness/ZDebug.PerfHarness.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/src/ZDebug.Terp/ViewModel/ScreenViewModel.cs
+++ b/src/ZDebug.Terp/ViewModel/ScreenViewModel.cs
@@ -7,6 +7,7 @@ using System.Windows.Media;
 using ZDebug.Core.Execution;
 using ZDebug.Core.Extensions;
 using ZDebug.IO.Services;
+using ZDebug.IO.Utilities;
 using ZDebug.IO.Windows;
 using ZDebug.UI.Extensions;
 using ZDebug.UI.Services;
@@ -76,7 +77,8 @@ namespace ZDebug.Terp.ViewModel
                 flowDirection: FlowDirection.LeftToRight,
                 typeface: new Typeface(FontsAndColorsService.FixedFontFamily, FontStyles.Normal, FontWeights.Normal, FontStretches.Normal),
                 emSize: FontsAndColorsService.FontSize,
-                foreground: Brushes.Black);
+                foreground: Brushes.Black,
+                pixelsPerDip: DpiHelper.GetPixelsPerDip());
         }
 
         private bool ForceFixedWidthFont()

--- a/src/ZDebug.Terp/ViewModel/ScreenViewModel.cs
+++ b/src/ZDebug.Terp/ViewModel/ScreenViewModel.cs
@@ -78,7 +78,7 @@ namespace ZDebug.Terp.ViewModel
                 typeface: new Typeface(FontsAndColorsService.FixedFontFamily, FontStyles.Normal, FontWeights.Normal, FontStretches.Normal),
                 emSize: FontsAndColorsService.FontSize,
                 foreground: Brushes.Black,
-                pixelsPerDip: DpiHelper.GetPixelsPerDip());
+                pixelsPerDip: this.View.GetPixelsPerDip());
         }
 
         private bool ForceFixedWidthFont()

--- a/src/ZDebug.Terp/ZDebug.Terp.csproj
+++ b/src/ZDebug.Terp/ZDebug.Terp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>WinExe</OutputType>
   </PropertyGroup>
 

--- a/src/ZDebug.Terp/ZDebug.Terp.csproj
+++ b/src/ZDebug.Terp/ZDebug.Terp.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <OutputType>WinExe</OutputType>
+    <UseWpf>true</UseWpf>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,23 +12,12 @@
     <ProjectReference Include="..\ZDebug.UI.Core\ZDebug.UI.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
-
   <PropertyGroup>
     <LanguageTargets>$(MSBuildToolsPath)\Microsoft.CSharp.targets</LanguageTargets>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="App.xaml" />
-    <ApplicationDefinition Include="App.xaml" Subtype="Designer" Generator="MSBuild:UpdateDesignTimeXaml" />
-    <Page Include="**\*.xaml" SubType="Designer" Generator="MSBuild:UpdateDesignTimeXaml" Exclude="App.xaml" />
-    <PackageReference Include="System.Composition" Version="1.1.0" />
-    <Compile Update="**\*.xaml.cs" SubType="Designer" DependentUpon="%(Filename)" />
+    <PackageReference Include="System.Composition" />
   </ItemGroup>
 
 </Project>

--- a/src/ZDebug.Terp/ZDebug.Terp.csproj
+++ b/src/ZDebug.Terp/ZDebug.Terp.csproj
@@ -12,10 +12,6 @@
     <ProjectReference Include="..\ZDebug.UI.Core\ZDebug.UI.Core.csproj" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <LanguageTargets>$(MSBuildToolsPath)\Microsoft.CSharp.targets</LanguageTargets>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="System.Composition" />
   </ItemGroup>

--- a/src/ZDebug.UI.Core/ZDebug.UI.Core.csproj
+++ b/src/ZDebug.UI.Core/ZDebug.UI.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ZDebug.UI.Core/ZDebug.UI.Core.csproj
+++ b/src/ZDebug.UI.Core/ZDebug.UI.Core.csproj
@@ -2,16 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
+    <UseWpf>true</UseWpf>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectCapability Include="DynamicDependentFile" />
-    <ProjectCapability Include="WindowsXaml;WindowsXamlPage;WindowsXamlCodeBehind;WindowsXamlResourceDictionary;WindowsXamlUserControl" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="AvalonDock-1.x" Version="1.3.3600.2" />
-    <PackageReference Include="System.Composition" Version="1.1.0" />
+    <PackageReference Include="AvalonDock-1.x" />
+    <PackageReference Include="System.Composition" />
   </ItemGroup>
 
   <ItemGroup>
@@ -19,24 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Resource Include="Images\*.png" />
-  </ItemGroup>
-
-  <PropertyGroup>
-    <LanguageTargets>$(MSBuildToolsPath)\Microsoft.CSharp.targets</LanguageTargets>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Resource Include="Resources\Images.xaml" Subtype="Designer" Generator="MSBuild:UpdateDesignTimeXaml" />
-    <Page Include="**\*.xaml" SubType="Designer" Generator="MSBuild:UpdateDesignTimeXaml" Exclude="Resources\Images.xaml" />
-    <Compile Update="**\*.xaml.cs" SubType="Designer" DependentUpon="%(Filename)" />
   </ItemGroup>
 
 </Project>

--- a/src/ZDebug.UI/ViewModel/DisassemblyViewModel.cs
+++ b/src/ZDebug.UI/ViewModel/DisassemblyViewModel.cs
@@ -8,6 +8,7 @@ using System.Windows.Media;
 using ZDebug.Core.Basics;
 using ZDebug.Core.Collections;
 using ZDebug.Core.Routines;
+using ZDebug.IO.Utilities;
 using ZDebug.UI.Collections;
 using ZDebug.UI.Controls;
 using ZDebug.UI.Extensions;
@@ -430,10 +431,24 @@ namespace ZDebug.UI.ViewModel
         {
             var typeface = new Typeface(this.View.FontFamily, this.View.FontStyle, this.View.FontWeight, this.View.FontStretch);
 
-            var addressText = new FormattedText("  000000: ", CultureInfo.InvariantCulture, FlowDirection.LeftToRight, typeface, this.View.FontSize, this.View.Foreground);
+            var addressText = new FormattedText(
+                "  000000: ",
+                CultureInfo.InvariantCulture, 
+                FlowDirection.LeftToRight, 
+                typeface, 
+                this.View.FontSize,
+                this.View.Foreground,
+                this.View.GetPixelsPerDip());
             this.View.Resources["addressWidth"] = new GridLength(addressText.WidthIncludingTrailingWhitespace);
 
-            var opcodeName = new FormattedText("check_arg_count  ", CultureInfo.InvariantCulture, FlowDirection.LeftToRight, typeface, this.View.FontSize, this.View.Foreground);
+            var opcodeName = new FormattedText(
+                "check_arg_count  ", 
+                CultureInfo.InvariantCulture, 
+                FlowDirection.LeftToRight, 
+                typeface, 
+                this.View.FontSize, 
+                this.View.Foreground,
+                this.View.GetPixelsPerDip());
             this.View.Resources["opcodeWidth"] = new GridLength(opcodeName.WidthIncludingTrailingWhitespace);
 
         }

--- a/src/ZDebug.UI/ViewModel/OutputViewModel.cs
+++ b/src/ZDebug.UI/ViewModel/OutputViewModel.cs
@@ -8,6 +8,7 @@ using System.Windows.Media;
 using ZDebug.Core.Execution;
 using ZDebug.Core.Extensions;
 using ZDebug.IO.Services;
+using ZDebug.IO.Utilities;
 using ZDebug.IO.Windows;
 using ZDebug.UI.Extensions;
 using ZDebug.UI.Services;
@@ -86,7 +87,8 @@ namespace ZDebug.UI.ViewModel
                 flowDirection: FlowDirection.LeftToRight,
                 typeface: new Typeface(FontsAndColorsService.FixedFontFamily, FontStyles.Normal, FontWeights.Normal, FontStretches.Normal),
                 emSize: FontsAndColorsService.FontSize,
-                foreground: Brushes.Black);
+                foreground: Brushes.Black,
+                pixelsPerDip: this.View.GetPixelsPerDip());
         }
 
         private bool ForceFixedWidthFont()

--- a/src/ZDebug.UI/ZDebug.UI.csproj
+++ b/src/ZDebug.UI/ZDebug.UI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>WinExe</OutputType>
   </PropertyGroup>
 

--- a/src/ZDebug.UI/ZDebug.UI.csproj
+++ b/src/ZDebug.UI/ZDebug.UI.csproj
@@ -3,41 +3,16 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <OutputType>WinExe</OutputType>
+    <UseWpf>true</UseWpf>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Views\MainWindowView.xaml" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Include="Views\MainWindowView.xaml" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.Composition" Version="1.1.0" />
+    <PackageReference Include="System.Composition" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\ZDebug.IO\ZDebug.IO.csproj" />
     <ProjectReference Include="..\ZDebug.UI.Core\ZDebug.UI.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
-
-  <PropertyGroup>
-    <LanguageTargets>$(MSBuildToolsPath)\Microsoft.CSharp.targets</LanguageTargets>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Remove="App.xaml" />
-    <ApplicationDefinition Include="App.xaml" Subtype="Designer" Generator="MSBuild:UpdateDesignTimeXaml" />
-    <Page Include="**\*.xaml" SubType="Designer" Generator="MSBuild:UpdateDesignTimeXaml" Exclude="App.xaml" />
-    <Compile Update="**\*.xaml.cs" SubType="Designer" DependentUpon="%(Filename)" />
   </ItemGroup>
 
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
-
-</Project>

--- a/tests/ZDebug.Compiler.Tests/ZDebug.Compiler.Tests.csproj
+++ b/tests/ZDebug.Compiler.Tests/ZDebug.Compiler.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/ZDebug.Compiler.Tests/ZDebug.Compiler.Tests.csproj
+++ b/tests/ZDebug.Compiler.Tests/ZDebug.Compiler.Tests.csproj
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ZDebug.Core.Tests/ZDebug.Core.Tests.csproj
+++ b/tests/ZDebug.Core.Tests/ZDebug.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/ZDebug.Core.Tests/ZDebug.Core.Tests.csproj
+++ b/tests/ZDebug.Core.Tests/ZDebug.Core.Tests.csproj
@@ -10,10 +10,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Moq" Version="4.7.142" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Use central package management
- Update net461 to net472
- Update netcoreapp2.0 to net9.0
- Clean up projects and props files
- Introduce DpiHelper.GetPixelsPerDIp() helper to avoid obsolete warnings